### PR TITLE
Controlling Input Focus with Pause & Resume

### DIFF
--- a/mooc/mooc/static/js/jsnes.js
+++ b/mooc/mooc/static/js/jsnes.js
@@ -2091,31 +2091,20 @@ JSNES.Keyboard.prototype = {
         return false; // preventDefault
     },
 
-    //keyDown: function(evt) {
-    //    if (!this.setKey(evt.keyCode, 0x41) && evt.preventDefault) {
-    //        evt.preventDefault();
-    //    }
-    //},
-    
-    //keyUp: function(evt) {
-    //    if (!this.setKey(evt.keyCode, 0x40) && evt.preventDefault) {
-    //        evt.preventDefault();
-    //    }
-    //},
-    
-    //keyPress: function(evt) {
-    //    evt.preventDefault();
-    //}
-    
     keyDown: function(evt) {
-        this.setKey(evt.keyCode, 0x41);
+        if (!this.setKey(evt.keyCode, 0x41) && evt.preventDefault) {
+            evt.preventDefault();
+        }
     },
     
     keyUp: function(evt) {
-        this.setKey(evt.keyCode, 0x40);
+        if (!this.setKey(evt.keyCode, 0x40) && evt.preventDefault) {
+            evt.preventDefault();
+        }
     },
     
     keyPress: function(evt) {
+        evt.preventDefault();
     }
 };
 

--- a/mooc/mooc/static/js/jsnes.js
+++ b/mooc/mooc/static/js/jsnes.js
@@ -93,6 +93,11 @@ JSNES.prototype = {
     start: function() {
         var self = this;
         
+        $(document).
+            bind('keydown', window.keydownevt).
+            bind('keyup', window.keyupevt).
+            bind('keypress', window.keypressevt);
+        
         if (this.rom !== null && this.rom.valid) {
             if (!this.isRunning) {
                 this.isRunning = true;
@@ -197,6 +202,11 @@ JSNES.prototype = {
         clearInterval(this.frameInterval);
         clearInterval(this.fpsInterval);
         this.isRunning = false;
+        
+        $(document).
+            unbind('keydown', window.keydownevt).
+            unbind('keyup', window.keyupevt).
+            unbind('keypress', window.keypressevt);
     },
     
     reloadRom: function() {
@@ -7017,16 +7027,17 @@ if (typeof jQuery !== 'undefined') {
                 /*
                  * Keyboard
                  */
-                $(document).
-                    bind('keydown', function(evt) {
-                        self.nes.keyboard.keyDown(evt); 
-                    }).
-                    bind('keyup', function(evt) {
-                        self.nes.keyboard.keyUp(evt); 
-                    }).
-                    bind('keypress', function(evt) {
-                        self.nes.keyboard.keyPress(evt);
-                    });
+                window.keydownevt = function(evt) {
+                    self.nes.keyboard.keyDown(evt); 
+                }
+                
+                window.keyupevt = function(evt) {
+                    self.nes.keyboard.keyUp(evt); 
+                }
+                
+                window.keypressevt = function(evt) {
+                    self.nes.keyboard.keyPress(evt);
+                }
             
                 /*
                  * Sound


### PR DESCRIPTION
Hey,

I moved event "binding" (jQuery lingo) to the start and stop functions. When you pause the emulator, the keyboard will be usable again. When you resume, the keyboard will direct events to the emulator only.

Part of the solution was hacky though. I didn't want to delve too far into how jQuery and JSNES were handling temporary data storage, so I put the DOM-level input handlers into the global scope (in the Window object).

Thanks!
pikpik
